### PR TITLE
Remove spanish word Fecha instead DateWrapper on Mars theme.

### DIFF
--- a/packages/mars-theme/src/components/post.js
+++ b/packages/mars-theme/src/components/post.js
@@ -43,10 +43,10 @@ const Post = ({ state, actions, libraries }) => {
                 </Author>
               </StyledLink>
             )}
-            <Fecha>
+            <DateWrapper>
               {" "}
               on <b>{date.toDateString()}</b>
-            </Fecha>
+            </DateWrapper>
           </div>
         )}
       </div>
@@ -90,7 +90,7 @@ const Author = styled.p`
   display: inline;
 `;
 
-const Fecha = styled.p`
+const DateWrapper = styled.p`
   color: rgba(12, 17, 43, 0.9);
   font-size: 0.9em;
   display: inline;


### PR DESCRIPTION
**Why**:

I know that is a small change, but looked weird taking a look to have a component named in Spanish while the entire theme is in English. This won't crash anything, promised.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->
- [x] npm run test 😆 
<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Update starter themes

**Unrelated Tasks**
- Code
- TSDocs
- TypeScript
- Unit tests
- End to end tests
- TypeScript tests
- Update other packages
- Link to PR in [Documentation](https://github.com/frontity/gitbook-docs/)
- Community discussions
- Changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)
<!-- Remove the "[ ]" from any non related task. -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->
